### PR TITLE
Update zeromq download location

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -25,7 +25,7 @@ distclean:
 
 $(DEPS)/zeromq4:
 	@mkdir -p $(DEPS)
-	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
+	@curl -L https://archive.org/download/zeromq_$(ZEROMQ_VERSION)/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
 	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq4
 
 $(DEPS)/zeromq4/src/.libs/libzmq.a: $(DEPS)/zeromq4


### PR DESCRIPTION
A fresh build was failing because the original URL was issuing a
redirect which curl wasn't following.  This adds the `-L` flag so future
redirects are followed and updates the URL to the current location.